### PR TITLE
Fix refinement log to use refined_pdb_file

### DIFF
--- a/Updated Code from Nature Paper.ipynb
+++ b/Updated Code from Nature Paper.ipynb
@@ -299,7 +299,7 @@
     "    logger.info(\"Starting MD simulation for complex refinement...\")\n",
     "    simulation.reporters.append(PDBReporter(refined_pdb_file, report_interval))\n",
     "    simulation.step(simulation_steps)\n",
-    "    logger.info(f\"MD refinement complete. Refined structure saved to {refined_complex_file}\")\n",
+    "    logger.info(f\"MD refinement complete. Refined structure saved to {refined_pdb_file}\")\n",
     "\n",
     "# =============================================================================\n",
     "# Step 9. Codon Optimization for Gene Synthesis\n",


### PR DESCRIPTION
## Summary
- use refined_pdb_file instead of refined_complex_file in in_silico_refinement log message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894a443c138832a9fa73da5c9224345